### PR TITLE
Create Command to View Backup Info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	gotest.tools/v3 v3.3.0
+	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 	k8s.io/cli-runtime v0.24.1
 	k8s.io/client-go v0.24.1
@@ -39,6 +40,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
@@ -60,7 +62,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.24.1 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -77,6 +78,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
@@ -95,6 +97,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -265,6 +268,7 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -281,13 +285,16 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
+github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
@@ -712,6 +719,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/cmd/pgo.go
+++ b/internal/cmd/pgo.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -65,8 +66,13 @@ pgo is a kubectl plugin for PGO, the open source Postgres Operator from Crunchy 
 	// add all the expected global flags
 	kubeconfig.AddFlags(root.PersistentFlags())
 
+	// Defined command output. If not set, it falls back to Stderr.
+	// - https://pkg.go.dev/github.com/spf13/cobra#Command.Printf
+	root.SetOut(os.Stdout)
+
 	root.AddCommand(newExampleCommand(kubeconfig))
 	root.AddCommand(newCreateCommand(kubeconfig))
+	root.AddCommand(newShowCommand(kubeconfig))
 
 	return root
 }

--- a/internal/cmd/show.go
+++ b/internal/cmd/show.go
@@ -1,0 +1,175 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/crunchydata/postgres-operator-client/internal/util"
+)
+
+// Executor calls commands
+type Executor func(
+	stdin io.Reader, stdout, stderr io.Writer, command ...string,
+) error
+
+// newShowCommand returns the show subcommand of the PGO plugin. The 'show' command
+// allows you to display particular details related to the PostgreSQL cluster.
+func newShowCommand(kubeconfig *genericclioptions.ConfigFlags) *cobra.Command {
+
+	cmdShow := &cobra.Command{
+		Use:   "show",
+		Short: "Show PostgresCluster details",
+		Long:  "Show allows you to display particular details related to the PostgresCluster",
+	}
+
+	cmdShow.AddCommand(
+		newShowBackupCommand(kubeconfig),
+	)
+
+	// No arguments for 'show', but there are arguments for the subcommands, e.g.
+	// 'show backup'
+	cmdShow.Args = cobra.NoArgs
+
+	return cmdShow
+}
+
+// newShowBackupCommand returns the backup subcommand of the show command. The
+// 'backup' command displays the output of the 'pgbackrest info' command.
+// - https://pgbackrest.org/command.html ('8 Info Command (info)')
+func newShowBackupCommand(kubeconfig *genericclioptions.ConfigFlags) *cobra.Command {
+
+	cmdShowBackup := &cobra.Command{
+		Use:     "backup",
+		Aliases: []string{"backups"},
+		Short:   "Show backup information for a PostgresCluster",
+		Long:    "Show backup information for a PostgresCluster from 'pgbackrest info' command.",
+	}
+
+	cmdShowBackup.Example = `  kubectl pgo show backup hippo
+  kubectl pgo show backup hippo --output=json
+  kubectl pgo show backup hippo --repoName=repo1
+	`
+
+	// Define the command flags.
+	// - https://pgbackrest.org/command.html
+	// - output: '8.1.1 Output Option (--output)'
+	// - repoName: '8.4.1 Set Repository Option (--repo)'
+	var output string
+	var repoName string
+	cmdShowBackup.Flags().StringVarP(&output, "output", "o", "text",
+		"output format. types supported: text,json")
+	cmdShowBackup.Flags().StringVar(&repoName, "repoName", "",
+		"Set the repository name for the command. example: repo1")
+
+	// Limit the number of args, that is, only one cluster name
+	cmdShowBackup.Args = cobra.ExactArgs(1)
+
+	// Define the 'show backup' command
+	cmdShowBackup.RunE = func(cmd *cobra.Command, args []string) error {
+
+		// This command returns before, after and found.
+		// The only thing we need is the value after 'repo' which should be an
+		// integer. If anything else is provided, we let the pgbackrest command
+		// handle validation.
+		_, repoNum, _ := strings.Cut(repoName, "repo")
+
+		// configure client
+		ctx := context.Background()
+		config, err := kubeconfig.ToRESTConfig()
+		if err != nil {
+			return err
+		}
+		client, err := dynamic.NewForConfig(config)
+		if err != nil {
+			return err
+		}
+
+		// Get the namespace. This will either be from the Kubernetes configuration
+		// or from the --namespace (-n) flag.
+		configNamespace, _, err := kubeconfig.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return err
+		}
+
+		// Get the primary instance Pod by its labels. For a Postgres cluster
+		// named 'hippo', we'll use the following:
+		//    postgres-operator.crunchydata.com/cluster=hippo
+		//    postgres-operator.crunchydata.com/data=postgres
+		//    postgres-operator.crunchydata.com/role=master
+		pods, err := client.Resource(schema.GroupVersionResource{
+			Version: "v1", Resource: "pods",
+		}).Namespace(configNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: util.PrimaryInstanceLabels(args[0]),
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(pods.Items) != 1 {
+			return fmt.Errorf("Primary instance Pod not found.")
+		}
+
+		PodExec, err := util.NewPodExecutor(config)
+		if err != nil {
+			return err
+		}
+
+		// Create an executor and attempt to get the pgBackRest info output.
+		exec := func(stdin io.Reader, stdout, stderr io.Writer,
+			command ...string) error {
+			return PodExec(pods.Items[0].GetNamespace(), pods.Items[0].GetName(),
+				util.ContainerDatabase, stdin, stdout, stderr, command...)
+		}
+		stdout, stderr, err := Executor(exec).pgBackRestInfo(output, repoNum)
+		if err != nil {
+			return err
+		}
+
+		// Print the output received.
+		cmd.Printf(stdout)
+		if stderr != "" {
+			cmd.Printf("\nError returned: %s\n", stderr)
+		}
+
+		return nil
+	}
+
+	return cmdShowBackup
+}
+
+// pgBackRestInfo defines a pgBackRest info command with relevant flags set
+func (exec Executor) pgBackRestInfo(output, repoNum string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	var command string
+
+	command = "pgbackrest info --output=" + output
+	if repoNum != "" {
+		command += " --repo=" + repoNum
+	}
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+
+	return stdout.String(), stderr.String(), err
+}

--- a/internal/cmd/show_test.go
+++ b/internal/cmd/show_test.go
@@ -1,0 +1,71 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPGBackRestInfo(t *testing.T) {
+
+	t.Run("default", func(t *testing.T) {
+		expected := errors.New("pass-through")
+		exec := func(
+			stdin io.Reader, stdout, stderr io.Writer, command ...string,
+		) error {
+			assert.DeepEqual(t, command, []string{"bash", "-ceu", "--", "pgbackrest info --output=text"})
+			assert.Assert(t, stdout != nil, "should capture stdout")
+			assert.Assert(t, stderr != nil, "should capture stderr")
+			return expected
+		}
+		_, _, err := Executor(exec).pgBackRestInfo("text", "")
+		assert.ErrorContains(t, err, "pass-through")
+
+	})
+
+	t.Run("text, repo 1", func(t *testing.T) {
+		expected := errors.New("pass-through")
+		exec := func(
+			stdin io.Reader, stdout, stderr io.Writer, command ...string,
+		) error {
+			assert.DeepEqual(t, command, []string{"bash", "-ceu", "--", "pgbackrest info --output=text --repo=1"})
+			assert.Assert(t, stdout != nil, "should capture stdout")
+			assert.Assert(t, stderr != nil, "should capture stderr")
+			return expected
+		}
+		_, _, err := Executor(exec).pgBackRestInfo("text", "1")
+		assert.ErrorContains(t, err, "pass-through")
+
+	})
+
+	t.Run("json, repo 2", func(t *testing.T) {
+		expected := errors.New("pass-through")
+		exec := func(
+			stdin io.Reader, stdout, stderr io.Writer, command ...string,
+		) error {
+			assert.DeepEqual(t, command, []string{"bash", "-ceu", "--", "pgbackrest info --output=json --repo=2"})
+			assert.Assert(t, stdout != nil, "should capture stdout")
+			assert.Assert(t, stderr != nil, "should capture stderr")
+			return expected
+		}
+		_, _, err := Executor(exec).pgBackRestInfo("json", "2")
+		assert.ErrorContains(t, err, "pass-through")
+
+	})
+}

--- a/internal/util/executor.go
+++ b/internal/util/executor.go
@@ -1,0 +1,68 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// podExecutor runs command on container in pod in namespace. Non-nil streams
+// (stdin, stdout, and stderr) are attached to the remote process.
+type podExecutor func(
+	namespace, pod, container string,
+	stdin io.Reader, stdout, stderr io.Writer, command ...string,
+) error
+
+// NewPodExecutor returns an executor function. It is used when commands are run
+// from a Container shell using an 'exec' command.
+// The RBAC settings required for this are "resources=pods/exec,verbs=create"
+func NewPodExecutor(config *rest.Config) (podExecutor, error) {
+
+	client, err := clientv1.NewForConfig(config)
+
+	return func(
+		namespace, pod, container string,
+		stdin io.Reader, stdout, stderr io.Writer, command ...string,
+	) error {
+		request := client.RESTClient().Post().
+			Resource("pods").SubResource("exec").
+			Namespace(namespace).Name(pod).
+			VersionedParams(&corev1.PodExecOptions{
+				Container: container,
+				Command:   command,
+				Stdin:     stdin != nil,
+				Stdout:    stdout != nil,
+				Stderr:    stderr != nil,
+			}, scheme.ParameterCodec)
+
+		exec, err := remotecommand.NewSPDYExecutor(config, "POST", request.URL())
+
+		if err == nil {
+			err = exec.Stream(remotecommand.StreamOptions{
+				Stdin:  stdin,
+				Stdout: stdout,
+				Stderr: stderr,
+			})
+		}
+
+		return err
+	}, err
+}

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -1,0 +1,61 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+const (
+	// Labels
+
+	// labelPrefix is the prefix common to all PostgresCluster object labels.
+	labelPrefix = "postgres-operator.crunchydata.com/"
+
+	// LabelCluster is used to label PostgresCluster objects.
+	LabelCluster = labelPrefix + "cluster"
+
+	// LabelData is used to identify Pods and Volumes store Postgres data.
+	LabelData = labelPrefix + "data"
+
+	// LabelRole is used to identify object roles.
+	LabelRole = labelPrefix + "role"
+)
+
+const (
+	// Data values
+
+	// DataPostgres is a LabelData value that indicates the object has PostgreSQL data.
+	DataPostgres = "postgres"
+)
+
+const (
+	// Role values
+
+	// RolePatroniLeader is the LabelRole that Patroni sets on the Pod that is
+	// currently the leader.
+	RolePatroniLeader = "master"
+)
+
+const (
+	// Container names
+
+	// ContainerDatabase is the name of the container running PostgreSQL and
+	// supporting tools: Patroni, pgBackRest, etc.
+	ContainerDatabase = "database"
+)
+
+// PrimaryInstanceLabels provides labels for a PostgreSQL cluster primary instance
+func PrimaryInstanceLabels(clusterName string) string {
+	return LabelCluster + "=" + clusterName + "," +
+		LabelData + "=" + DataPostgres + "," +
+		LabelRole + "=" + RolePatroniLeader
+}

--- a/internal/util/naming_test.go
+++ b/internal/util/naming_test.go
@@ -1,0 +1,29 @@
+// Copyright 2021 - 2022 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestPrimaryInstanceLabels(t *testing.T) {
+
+	assert.Equal(t, PrimaryInstanceLabels("testcluster1"),
+		"postgres-operator.crunchydata.com/cluster=testcluster1,"+
+			"postgres-operator.crunchydata.com/data=postgres,"+
+			"postgres-operator.crunchydata.com/role=master")
+}

--- a/testing/kuttl/e2e/show-backup/00--cluster.yaml
+++ b/testing/kuttl/e2e/show-backup/00--cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: show-backup-cluster
+spec:
+  postgresVersion: 14
+  instances:
+    - name: instance1
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/testing/kuttl/e2e/show-backup/00-assert.yaml
+++ b/testing/kuttl/e2e/show-backup/00-assert.yaml
@@ -1,0 +1,49 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: show-backup-cluster
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+    - bound: true
+      name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: show-backup-cluster
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+status:
+  succeeded: 1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: show-backup-cluster
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest: ""
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+    postgres-operator.crunchydata.com/pgbackrest-volume: ""
+  name: show-backup-cluster-repo1
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+status:
+  phase: Bound

--- a/testing/kuttl/e2e/show-backup/01--pgbackrest-info.yaml
+++ b/testing/kuttl/e2e/show-backup/01--pgbackrest-info.yaml
@@ -1,0 +1,32 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=show-backup-cluster,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+    EXEC_INFO=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -- \
+          pgbackrest info
+    )
+
+    CLI_INFO=$(
+        kubectl-pgo --namespace "${NAMESPACE}" show backup show-backup-cluster
+    )
+
+    status=$?
+    if [ $status -ne 0 ]; then
+        echo "pgo command unsuccessful"
+        exit 1
+    fi
+
+    # check command output is not empty and equals 'exec' output
+    if [[ -n $CLI_INFO && "$EXEC_INFO" == "$CLI_INFO" ]]; then
+        exit 0
+    fi
+
+    exit 1

--- a/testing/kuttl/e2e/show-backup/02--pgbackrest-info-repo1.yaml
+++ b/testing/kuttl/e2e/show-backup/02--pgbackrest-info-repo1.yaml
@@ -1,0 +1,33 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=show-backup-cluster,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+    EXEC_INFO=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -- \
+          pgbackrest info --repo=1
+    )
+
+    CLI_INFO=$(
+        kubectl-pgo --namespace "${NAMESPACE}" show backup show-backup-cluster \
+          --repoName=repo1
+    )
+
+    status=$?
+    if [ $status -ne 0 ]; then
+        echo "pgo command unsuccessful"
+        exit 1
+    fi
+
+    # check command output is not empty and equals 'exec' output
+    if [[ -n $CLI_INFO && "$EXEC_INFO" == "$CLI_INFO" ]]; then
+        exit 0
+    fi
+
+    exit 1

--- a/testing/kuttl/e2e/show-backup/03--pgbackrest-info-output.yaml
+++ b/testing/kuttl/e2e/show-backup/03--pgbackrest-info-output.yaml
@@ -1,0 +1,33 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: |
+    PRIMARY=$(
+        kubectl get pod --namespace "${NAMESPACE}" \
+          --output name --selector '
+            postgres-operator.crunchydata.com/cluster=show-backup-cluster,
+            postgres-operator.crunchydata.com/role=master'
+      )
+
+    EXEC_INFO=$(
+        kubectl exec --namespace "${NAMESPACE}" "${PRIMARY}" -- \
+          pgbackrest info --output=json
+    )
+
+    CLI_INFO=$(
+        kubectl-pgo --namespace "${NAMESPACE}" show backup show-backup-cluster \
+          --output=json
+    )
+
+    status=$?
+    if [ $status -ne 0 ]; then
+        echo "pgo command unsuccessful"
+        exit 1
+    fi
+
+    # check command output is not empty and equals 'exec' output
+    if [[ -n $CLI_INFO && "$EXEC_INFO" == "$CLI_INFO" ]]; then
+        exit 0
+    fi
+
+    exit 1

--- a/testing/kuttl/kuttl-test.yaml
+++ b/testing/kuttl/kuttl-test.yaml
@@ -2,7 +2,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - testing/kuttl/e2e/
-timeout: 45
+timeout: 90
 parallel: 2
 # by default kuttl will run in a generated namespace to override
 # that functionality simply uncomment the line below and replace


### PR DESCRIPTION
Adds a command to the pgo CLI to show the output of the 'pgbackrest
info' command. It allows for flags to specify both the repo name
and the output type. It assumes a user running pgo will have 'exec'
RBAC permissions to facilitate executing the necessary pgBackRest
command.

Issue: [sc-14640]