### PR TITLE
Exclude testing packages from the executable

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - gofumpt
     - scopelint
   enable:
+    - depguard
     - goheader
     - gomodguard
     - gosimple
@@ -20,6 +21,20 @@ linters:
     - unused
 
 linters-settings:
+  depguard:
+    include-go-root: true
+    packages-with-error-message:
+      - io/ioutil: >
+          Use the "io" and "os" packages instead.
+          See https://go.dev/doc/go1.16#ioutil
+
+      - gotest.tools: Should be used only in tests.
+      - net/http/httptest: Should be used only in tests.
+      - testing: The "testing" packages should be used only in tests.
+
+      - github.com/crunchydata/postgres-operator-client/internal/testing: >
+          The "internal/testing" packages should be used only in tests.
+
   gci:
     sections:
       - standard
@@ -69,3 +84,10 @@ linters-settings:
 issues:
   # https://github.com/golangci/golangci-lint/issues/2239
   exclude-use-default: false
+
+  exclude-rules:
+    # These testing packages are allowed in test files. The packages are
+    # disallowed everywhere then ignored here because that is how depguard works.
+    - linters: [depguard]
+      path: ^internal/testing|_test[.]go$
+      text: \`(gotest.tools[^`]*|net/http/httptest|[^`]*testing[^`]*)`

--- a/internal/cmd/create_test.go
+++ b/internal/cmd/create_test.go
@@ -19,7 +19,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/crunchydata/postgres-operator-client/internal/util"
+	"github.com/crunchydata/postgres-operator-client/internal/testing/cmp"
 )
 
 func TestGenerateUnstructuredYaml(t *testing.T) {
@@ -53,7 +53,7 @@ spec:
 	u, err := generateUnstructuredClusterYaml("hippo")
 	assert.NilError(t, err)
 
-	assert.Assert(t, util.MarshalMatches(
+	assert.Assert(t, cmp.MarshalMatches(
 		interface{}(u),
 		expect,
 	))

--- a/internal/testing/cmp/cmp.go
+++ b/internal/testing/cmp/cmp.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package cmp
 
 import (
 	"strings"


### PR DESCRIPTION
The `util` package was importing `gotest.tools` causing it to be included in the binary. This moves that import into a separate package and adds a lint rule ([taken from postgres-operator](https://github.com/CrunchyData/postgres-operator/blob/d3300d2f2f1385ffc483bdb55af60ef1a28c0515/.golangci.yaml#L22)) to ensure test packages are used only in tests.

Before:

```
● go version -m ./bin/kubectl-pgo | wc -l
      64
● go version -m ./bin/kubectl-pgo | grep gotest
        dep     gotest.tools/v3 v3.3.0  h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
```

After:

```
● go version -m ./bin/kubectl-pgo | wc -l
      62
```

```diff
-       dep     github.com/google/go-cmp        v0.5.5  h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-       dep     gotest.tools/v3 v3.3.0  h1:MfDY1b1/0xN1CyMlQDac0ziEy9zJQd9CXBRRDHw2jJo=
```