### PR TITLE
Clean up error output

### DIFF
--- a/cmd/kubectl-pgo/main.go
+++ b/cmd/kubectl-pgo/main.go
@@ -28,6 +28,5 @@ func main() {
 	pflag.CommandLine = flags
 
 	root := cmd.NewPGOCommand(os.Stdin, os.Stdout, os.Stderr)
-
 	cobra.CheckErr(root.Execute())
 }


### PR DESCRIPTION
The CLI error output used to
* print the help output along with the error
* duplicate the error

This adjust the error output so that only it prints and only once by

* setting the SilenceUsage boolean in the root command;
* remove an unnecessary CheckErr

Issue [sc-15177]