### PR TITLE
add import for OpenID Connect auth

### DIFF
--- a/internal/cmd/pgo.go
+++ b/internal/cmd/pgo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"github.com/crunchydata/postgres-operator-client/internal"
 )


### PR DESCRIPTION
At the moment the pgo client will not work with k8s clusters that use OpenID Connect for authentication:
```
$ kubectl pgo version
Client Version: v0.2.0
Error: no Auth Provider found for name "oidc"
```

This PR adds the required module.


Tested with linux/amd64 so far. Unfortunately i don't have machines to test the remaining target platforms.