### PR TITLE
Add current timestamp to files in support export .tar file

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -766,9 +766,10 @@ func gatherPatroniInfo(ctx context.Context,
 // writeTar takes content as a byte slice and writes the content to a tar writer
 func writeTar(tw *tar.Writer, content []byte, name string, cmd *cobra.Command) error {
 	hdr := &tar.Header{
-		Name: name,
-		Mode: 0600,
-		Size: int64(len(content)),
+		Name:    name,
+		Mode:    0600,
+		ModTime: time.Now(),
+		Size:    int64(len(content)),
 	}
 
 	// TODO (jmckulk): figure out what support tool output looks like and make


### PR DESCRIPTION
Adds a timestamp to each file created for the support export .tar file. Value includes timezone information.

Issue: [sc-17845]