### PR TITLE
Add monitoring Pod log capture and improve associated tests

### DIFF
--- a/docs/content/reference/pgo_support_export.md
+++ b/docs/content/reference/pgo_support_export.md
@@ -46,14 +46,19 @@ pgo support export CLUSTER_NAME [flags]
   
   # Long Flags
   kubectl pgo support export daisy --output . --pg-logs-count 2
+  
+  # Monitoring namespace override
+  # This is only required when monitoring is not deployed in the PostgresCluster's namespace.
+  kubectl pgo support export daisy --monitoring-namespace another-namespace --output .
 ```
 
 ### Options
 
 ```
-  -h, --help                help for export
-  -o, --output string       Path to save export tarball
-  -l, --pg-logs-count int   Number of pg_log files to save (default 2)
+  -h, --help                          help for export
+      --monitoring-namespace string   Monitoring namespace override
+  -o, --output string                 Path to save export tarball
+  -l, --pg-logs-count int             Number of pg_log files to save (default 2)
 ```
 
 ### Options inherited from parent commands

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -28,6 +28,9 @@ const (
 
 	// LabelRole is used to identify object roles.
 	LabelRole = labelPrefix + "role"
+
+	// LabelMonitoring is used to identify monitoring Pods
+	LabelMonitoring = "app.kubernetes.io/name=postgres-operator-monitoring"
 )
 
 const (

--- a/testing/kuttl/e2e/support-export/20--create_cluster_with_monitoring.yaml
+++ b/testing/kuttl/e2e/support-export/20--create_cluster_with_monitoring.yaml
@@ -1,0 +1,78 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: kuttl-support-monitoring-cluster
+spec:
+  postgresVersion: 14
+  instances:
+    - dataVolumeClaimSpec:
+        accessModes: [ReadWriteOnce]
+        resources: { requests: { storage: 1Gi } }
+  backups:
+    pgbackrest:
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes: [ReadWriteOnce]
+            resources: { requests: { storage: 1Gi } }
+  monitoring:
+    pgmonitor:
+      exporter: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-operator-monitoring
+      name: crunchy-prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-operator-monitoring
+        name: crunchy-prometheus
+    spec:
+      containers:
+      - image: prom/prometheus:v2.33.5
+        name: prometheus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-grafana
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-operator-monitoring
+      name: crunchy-grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-operator-monitoring
+        name: crunchy-grafana
+    spec:
+      containers:
+      - image: grafana/grafana:8.5.10
+        name: grafana
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-alertmanager
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-operator-monitoring
+      name: crunchy-alertmanager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-operator-monitoring
+        name: crunchy-alertmanager
+    spec:
+      containers:
+      - image: prom/alertmanager:v0.22.2
+        name: alertmanager

--- a/testing/kuttl/e2e/support-export/20-assert.yaml
+++ b/testing/kuttl/e2e/support-export/20-assert.yaml
@@ -1,0 +1,65 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: kuttl-support-monitoring-cluster
+spec:
+  backups:
+    pgbackrest:
+      repos:
+        - name: repo1
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - "ReadWriteOnce"
+              resources:
+                requests:
+                  storage: 1Gi
+  instances:
+    - dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 1Gi
+      replicas: 1
+  postgresVersion: 14
+status:
+  instances:
+    - name: "00"
+      readyReplicas: 1
+      replicas: 1
+      updatedReplicas: 1
+  monitoring: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-prometheus
+status:
+  availableReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-grafana
+status:
+  availableReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crunchy-alertmanager
+status:
+  availableReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1

--- a/testing/kuttl/e2e/support-export/21--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/21--support_export.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: kubectl-pgo --namespace $NAMESPACE support export kuttl-support-monitoring-cluster -o .
+- script: tar -xf ./crunchy_k8s_support_export_*.tar
+- script: |
+    #!/bin/bash
+
+    CLEANUP="rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar"
+    CLUSTER_DIR="./kuttl-support-monitoring-cluster/logs/"
+    MONITORING_DIR="./monitoring/logs/"
+
+    # check for exporter, prometheus, grafana and alertmanager logs
+    found=$(find ${CLUSTER_DIR} -name "exporter" | wc -l)
+    if [ "${found}" -eq 0 ]; then
+      echo "exporter not found"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    found=$(find ${MONITORING_DIR} -name "prometheus" | wc -l)
+    if [ "${found}" -eq 0 ]; then
+      echo "prometheus not found"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    found=$(find ${MONITORING_DIR} -name "grafana" | wc -l)
+    if [ "${found}" -eq 0 ]; then
+      echo "grafana not found"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    found=$(find ${MONITORING_DIR} -name "alertmanager" | wc -l)
+    if [ "${found}" -eq 0 ]; then
+      echo "alertmanager not found"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+- script: rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar


### PR DESCRIPTION
This update adds the logs from the Grafana, Prometheus and Alertmanager Pods to the support export archive. By default, the support export command will look in the same namespace as the given PostgresCluster. For cases where the monitoring Pods run in a separate namespace, an override flag, --monitoring-namespace, is provided. Note that monitoring logs are only gathered from a single namespace at a time.

Additionally, this update adds associated tests for the monitoring logs to include the Pods mentioned above and the Postgres exporter sidecar container when defined in the PostgresCluster spec.

Issues:
[sc-17848]
[sc-17691]