### PR TITLE
Override Prometheus container command

### DIFF
--- a/testing/kuttl/e2e/support-export/20--create_cluster_with_monitoring.yaml
+++ b/testing/kuttl/e2e/support-export/20--create_cluster_with_monitoring.yaml
@@ -38,6 +38,9 @@ spec:
       containers:
       - image: prom/prometheus:v2.33.5
         name: prometheus
+        # Override default command to avoid 'permission denied' error in some
+        # environments (e.g. Openshift). Echo 'hello' so the Pod log is not empty.
+        command: ["sh", "-c", "while true; do echo hello; sleep 10;done"]
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This change overrides the Prometheus container's default command to avoid a 'permission denied' error in some environments (e.g. Openshift).

This happens because the Kuttl test is defining a 'dummy' deployment that is not configured for actual use. As such, overriding the command does not impact the validity of the test.

Issue: [sc-17848]