### PR TITLE
Accurate event recording by support export

### DIFF
--- a/docs/content/reference/pgo_support_export.md
+++ b/docs/content/reference/pgo_support_export.md
@@ -34,6 +34,12 @@ PostgresCluster.
 
     Note: This RBAC needs to be cluster-scoped to retrieve information on nodes.
 
+#### Event Capture
+    Support export captures all Events in the PostgresCluster's Namespace.
+    Event duration is determined by the '--event-ttl' setting of the Kubernetes
+    API server. Default is 1 hour.
+    - https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+
 ```
 pgo support export CLUSTER_NAME [flags]
 ```

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -134,7 +134,13 @@ PostgresCluster.
     services                                            [get list]
     statefulsets.apps                                   [get list]
 
-    Note: This RBAC needs to be cluster-scoped to retrieve information on nodes.`,
+    Note: This RBAC needs to be cluster-scoped to retrieve information on nodes.
+
+#### Event Capture
+    Support export captures all Events in the PostgresCluster's Namespace.
+    Event duration is determined by the '--event-ttl' setting of the Kubernetes
+    API server. Default is 1 hour.
+    - https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/`,
 	}
 
 	// Set output to log and write to buffer for writing to file
@@ -615,6 +621,9 @@ func gatherEvents(ctx context.Context,
 			event.InvolvedObject.Kind, event.InvolvedObject.Name,
 			strings.TrimSpace(event.Message),
 		)
+	}
+	if err := p.Flush(); err != nil {
+		return err
 	}
 
 	path := clusterName + "/events"

--- a/internal/cmd/pgo.go
+++ b/internal/cmd/pgo.go
@@ -18,7 +18,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -82,9 +82,9 @@ func NewPGOCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	cobra.AddTemplateFunc("replaceAll", strings.ReplaceAll)
+	cobra.AddTemplateFunc("formatHeader", formatHeader)
 
-	root.SetHelpTemplate(`{{with .Long}}{{ replaceAll . "#### RBAC Requirements" "RBAC Requirements:" | trimTrailingWhitespaces }}
+	root.SetHelpTemplate(`{{with .Long}}{{ formatHeader . | trimTrailingWhitespaces }}
 
 {{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`)
 
@@ -106,4 +106,10 @@ func NewPGOCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 	root.AddCommand(newVersionCommand(config))
 
 	return root
+}
+
+// formatHeader removes markdown header syntax for CLI help output
+func formatHeader(s string) string {
+	re := regexp.MustCompile(`#### (.*)\n`)
+	return re.ReplaceAllString(s, "$1:\n")
 }

--- a/internal/cmd/pgo_test.go
+++ b/internal/cmd/pgo_test.go
@@ -1,0 +1,42 @@
+// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFormatHeader(t *testing.T) {
+	testsCases := []struct {
+		desc   string
+		input  string
+		output string
+	}{
+		{"Expected", "#### Some Header\n", "Some Header:\n"},
+		{"One valid, one not", "#### Some Header\n#### Another Header", "Some Header:\n#### Another Header"},
+		{"Two expected", "#### Some Header\n#### Another Header\n", "Some Header:\nAnother Header:\n"},
+		{"No newline", "#### Some Header", "#### Some Header"},
+		{"3 hashes", "### Some Header\n", "### Some Header\n"},
+		{"leading space", " #### Some Header\n", " Some Header:\n"},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, formatHeader(tc.input), tc.output)
+		})
+	}
+}

--- a/testing/kuttl/e2e/support-export/01--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/01--support_export.yaml
@@ -32,4 +32,22 @@ commands:
       exit 1
     fi
 
+    # check that the events file exist and is not empty
+    EVENTS="./kuttl-support-cluster/events"
+
+    if [[ ! -s $EVENTS ]]
+    then
+      echo "Expected Events file to not be empty"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    # check that the events file contains the expected string
+    if ! grep -Fq "Created container postgres-startup" $EVENTS
+    then
+      echo "Events file does not contain expected string"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
 - script: rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar


### PR DESCRIPTION
This update corrects the current behavior of the support export command's event capture, adds relevant Kuttl checks and documents Kubernetes Event storage duration.

Issue: [sc-17993]