### PR TITLE
Support Export Compression

### DIFF
--- a/testing/kuttl/e2e/support-export/01--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/01--support_export.yaml
@@ -3,14 +3,23 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - script: kubectl-pgo --namespace $NAMESPACE support export kuttl-support-cluster -o .
-- script: tar -xf ./crunchy_k8s_support_export_*.tar
+- script: tar -xf ./crunchy_k8s_support_export_*.tar.gz
 - script: |
     #!/bin/bash
 
     DIR="./kuttl-support-cluster/nodes/"
     LIST="${DIR}list"
 
-    CLEANUP="rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar"
+    CLEANUP="rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar.gz"
+
+    # check for expected gzip compression level
+    FILE_INFO=$(file ./crunchy_k8s_support_export_*.tar.gz)
+    [[ "${FILE_INFO}" == *'gzip compressed data, max compression'* ]] || {
+      echo "Expected gzip max compression message, got:"
+      echo "${FILE_INFO}"
+      eval "$CLEANUP"
+      exit 1
+    }
 
     # check for expected table header in the list file
     KV=$(awk 'NR==1 {print $9}' $LIST)
@@ -50,4 +59,4 @@ commands:
       exit 1
     fi
 
-- script: rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar
+- script: rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar.gz

--- a/testing/kuttl/e2e/support-export/21--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/21--support_export.yaml
@@ -3,11 +3,11 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - script: kubectl-pgo --namespace $NAMESPACE support export kuttl-support-monitoring-cluster -o .
-- script: tar -xf ./crunchy_k8s_support_export_*.tar
+- script: tar -xf ./crunchy_k8s_support_export_*.tar.gz
 - script: |
     #!/bin/bash
 
-    CLEANUP="rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar"
+    CLEANUP="rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar.gz"
     CLUSTER_DIR="./kuttl-support-monitoring-cluster/logs/"
     MONITORING_DIR="./monitoring/logs/"
 
@@ -40,4 +40,4 @@ commands:
       exit 1
     fi
 
-- script: rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar
+- script: rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar.gz


### PR DESCRIPTION
This update changes the support export command to produce a compressed .tar.gz file instead of an uncompressed .tar file. Relevant tests are updated accordingly.

Issue: [sc-18010]