### PR TITLE
Support export size detail message / PGO CLI version in export

### DIFF
--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -270,10 +270,14 @@ kubectl pgo support export daisy --monitoring-namespace another-namespace --outp
 		}()
 
 		// TODO (jmckulk): collect context info
-		// TODO (jmckulk): collect client version, after pgo version command is implemented
+
+		// PGO CLI version
+		err = gatherPGOCLIVersion(ctx, clusterName, tw, cmd)
 
 		// Gather cluster wide resources
-		err = gatherKubeServerVersion(ctx, discoveryClient, clusterName, tw, cmd)
+		if err == nil {
+			err = gatherKubeServerVersion(ctx, discoveryClient, clusterName, tw, cmd)
+		}
 
 		if err == nil {
 			err = gatherNodes(ctx, clientset, clusterName, tw, cmd)
@@ -355,6 +359,20 @@ func exportSizeReport(size float64) string {
 	}
 
 	return finalMsg
+}
+
+// gatherPGOCLIVersion collects the PGO CLI version
+func gatherPGOCLIVersion(_ context.Context,
+	clusterName string,
+	tw *tar.Writer,
+	cmd *cobra.Command,
+) error {
+
+	path := clusterName + "/pgo-cli-version"
+	if err := writeTar(tw, []byte(clientVersion), path, cmd); err != nil {
+		return err
+	}
+	return nil
 }
 
 // gatherKubeServerVersion collects the server version from the Kubernetes cluster

--- a/internal/cmd/export_test.go
+++ b/internal/cmd/export_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 - 2023 Crunchy Data Solutions, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFileSizeReport(t *testing.T) {
+	testsCases := []struct {
+		desc   string
+		bytes  float64
+		output string
+	}{
+		{"Zero value", 0, fmt.Sprintf(msg1, 0/mebibyte)},
+		{"Less than 25 MiB", 10000, fmt.Sprintf(msg1, 10000/mebibyte)},
+		{"25 MiB", 26214400, fmt.Sprintf(msg1, 26214400/mebibyte)},
+		{"25 MiB + 1 byte", 26214401,
+			fmt.Sprintf(msg1, 26214401/mebibyte) + fmt.Sprintf(msg2, 26214400/mebibyte)},
+		{"3 GiB", 3221225472,
+			fmt.Sprintf(msg1, 3221225472/mebibyte) + fmt.Sprintf(msg2, 3221225472/mebibyte)},
+		{"Something went wrong...", -1, fmt.Sprintf(msg1, -1/mebibyte)},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, exportSizeReport(tc.bytes), tc.output)
+		})
+	}
+}

--- a/internal/cmd/pgo.go
+++ b/internal/cmd/pgo.go
@@ -29,7 +29,7 @@ import (
 )
 
 // store the current PGO CLI version
-const clientVersion = "v0.2.0"
+const clientVersion = "v0.3.0"
 
 // NewPGOCommand returns the root command of the PGO plugin. This command
 // prints the same information as its --help flag: the available subcommands

--- a/testing/kuttl/e2e/support-export/01--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/01--support_export.yaml
@@ -7,10 +7,16 @@ commands:
 - script: |
     #!/bin/bash
 
-    DIR="./kuttl-support-cluster/nodes/"
-    LIST="${DIR}list"
-
     CLEANUP="rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar.gz"
+
+    # check that the PGO CLI version is recorded
+    VER=$(cat ./kuttl-support-cluster/pgo-cli-version)
+    [[ "$VER" =~ v[0-9]+.[0-9]+.[0-9]+$ ]] || {
+      echo "Expected PGO CLI version, got:"
+      echo "${VER}"
+      eval "$CLEANUP"
+      exit 1
+    }
 
     # check for expected gzip compression level
     FILE_INFO=$(file ./crunchy_k8s_support_export_*.tar.gz)
@@ -20,6 +26,10 @@ commands:
       eval "$CLEANUP"
       exit 1
     }
+
+    # Node directory and list file path
+    DIR="./kuttl-support-cluster/nodes/"
+    LIST="${DIR}list"
 
     # check for expected table header in the list file
     KV=$(awk 'NR==1 {print $9}' $LIST)


### PR DESCRIPTION
With this update, the support export command now reports the resulting archive file's size along with usage instructions. In cases where the file is larger than 25MiB, an additional note is displayed with further instructions due to common email attachment size limits.

A second commit adds the PGO CLI version to the information collected by the support export command.
    
Issue: [sc-18005]
Issue: [sc-18016]