### PR TITLE
Capture process information in support export archive

### DIFF
--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -69,3 +69,13 @@ func (exec Executor) patronictl(cmd string) (string, string, error) {
 
 	return stdout.String(), stderr.String(), err
 }
+
+// processes returns the output of a ps command
+func (exec Executor) processes() (string, string, error) {
+	var stdout, stderr bytes.Buffer
+
+	command := "ps aux --width 500"
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+
+	return stdout.String(), stderr.String(), err
+}

--- a/internal/cmd/exec_test.go
+++ b/internal/cmd/exec_test.go
@@ -126,3 +126,22 @@ func TestPatronictl(t *testing.T) {
 	})
 
 }
+
+func TestProcesses(t *testing.T) {
+
+	t.Run("default", func(t *testing.T) {
+		expected := errors.New("pass-through")
+		exec := func(
+			stdin io.Reader, stdout, stderr io.Writer, command ...string,
+		) error {
+			assert.DeepEqual(t, command, []string{"bash", "-ceu", "--", "ps aux --width 500"})
+			assert.Assert(t, stdout != nil, "should capture stdout")
+			assert.Assert(t, stderr != nil, "should capture stderr")
+			return expected
+		}
+		_, _, err := Executor(exec).processes()
+		assert.ErrorContains(t, err, "pass-through")
+
+	})
+
+}

--- a/testing/kuttl/e2e/support-export/01--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/01--support_export.yaml
@@ -69,4 +69,28 @@ commands:
       exit 1
     fi
 
+    PROCESSES_DIR="./kuttl-support-cluster/processes/"
+
+    # Check for the files that contain an expected pgBackRest server process.
+    # Expected to be found in the Postgres instance Pod's 'database',
+    # 'replication-cert-copy', 'pgbackrest', and 'pgbackrest-config' containers
+    # and the pgBackRest repo Pod's 'pgbackrest' and 'pgbackrest-config'
+    # containers, i.e. 6 files total.
+    found=$(grep -lR "pgbackrest server" ${PROCESSES_DIR} | wc -l)
+    if [ "${found}" -ne 6 ]; then
+      echo "Expected to find 6 pgBackRest processes, got ${found}"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    # Check for the files that contain an expected Postgres process. Expected
+    # to be found in the Postgres instance Pod's 'database', 'replication-cert-copy',
+    # 'pgbackrest', and 'pgbackrest-config' containers, i.e. 4 files total.
+    found=$(grep -lR "postgres -D /pgdata/pg" ${PROCESSES_DIR} | wc -l)
+    if [ "${found}" -ne 4 ]; then
+      echo "Expected to find 4 Postgres processes, got ${found}"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
 - script: rm -r ./kuttl-support-cluster ./crunchy_k8s_support_export_*.tar.gz

--- a/testing/kuttl/e2e/support-export/README
+++ b/testing/kuttl/e2e/support-export/README
@@ -22,6 +22,7 @@ in this test. Over time, we should build on these tests to improve coverage.
     - compression level
     - Node "list" and YAML files
     - Event file
+    - Pod Processes
     The support export archive is deleted.
 
 #### Invalid Cluster


### PR DESCRIPTION
This update adds the capture of running processes for each Pod of the selected PostgresCluster. The 'ps' command is run on any possible container in the cluster, but only successful results are stored in the archive.

Issue: [sc-18017]