### PR TITLE
Address support export Kuttl test race condition

### DIFF
--- a/testing/kuttl/e2e/support-export/00-assert.yaml
+++ b/testing/kuttl/e2e/support-export/00-assert.yaml
@@ -29,3 +29,13 @@ status:
       readyReplicas: 1
       replicas: 1
       updatedReplicas: 1
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+    - bound: true
+      name: repo1
+      replicaCreateBackupComplete: true
+      stanzaCreated: true


### PR DESCRIPTION
Adds a Kuttl assert to verify that the initial pgBackRest backup has completed before moving on to the first support export archive content test. This is required because slowness in certain environments resulted in unnexpected archive content for the process gathering steps.

Issue: [sc-18017]