### PR TITLE
Improve support export self-logging

### DIFF
--- a/internal/cmd/export_test.go
+++ b/internal/cmd/export_test.go
@@ -27,14 +27,12 @@ func TestFileSizeReport(t *testing.T) {
 		bytes  float64
 		output string
 	}{
-		{"Zero value", 0, fmt.Sprintf(msg1, 0/mebibyte)},
-		{"Less than 25 MiB", 10000, fmt.Sprintf(msg1, 10000/mebibyte)},
-		{"25 MiB", 26214400, fmt.Sprintf(msg1, 26214400/mebibyte)},
-		{"25 MiB + 1 byte", 26214401,
-			fmt.Sprintf(msg1, 26214401/mebibyte) + fmt.Sprintf(msg2, 26214400/mebibyte)},
-		{"3 GiB", 3221225472,
-			fmt.Sprintf(msg1, 3221225472/mebibyte) + fmt.Sprintf(msg2, 3221225472/mebibyte)},
-		{"Something went wrong...", -1, fmt.Sprintf(msg1, -1/mebibyte)},
+		{"Zero value", 0, preBox + fmt.Sprintf(msg1, 0/mebibyte) + postBox + "\n"},
+		{"Less than 25 MiB", 10000, preBox + fmt.Sprintf(msg1, 10000/mebibyte) + postBox + "\n"},
+		{"25 MiB", 26214400, preBox + fmt.Sprintf(msg1, 26214400/mebibyte) + postBox + "\n"},
+		{"25 MiB + 1 byte", 26214401, preBox + fmt.Sprintf(msg2, 26214400/mebibyte) + postBox + "\n"},
+		{"3 GiB", 3221225472, preBox + fmt.Sprintf(msg2, 3221225472/mebibyte) + postBox + "\n"},
+		{"Something went wrong...", -1, preBox + fmt.Sprintf(msg1, -1/mebibyte) + postBox + "\n"},
 	}
 
 	for _, tc := range testsCases {

--- a/testing/kuttl/e2e/support-export/01--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/01--support_export.yaml
@@ -18,6 +18,15 @@ commands:
       exit 1
     }
 
+    # check that the context file exist and is not empty
+    if [[ ! -s ./kuttl-support-cluster/current-context ]]
+    then
+      echo "Expected context file to not be empty"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+
     # check for expected gzip compression level
     FILE_INFO=$(file ./crunchy_k8s_support_export_*.tar.gz)
     [[ "${FILE_INFO}" == *'gzip compressed data, max compression'* ]] || {
@@ -89,6 +98,25 @@ commands:
     found=$(grep -lR "postgres -D /pgdata/pg" ${PROCESSES_DIR} | wc -l)
     if [ "${found}" -ne 4 ]; then
       echo "Expected to find 4 Postgres processes, got ${found}"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    # check that the PGO CLI log file contains expected messages
+    CLI_LOG="./kuttl-support-cluster/logs/cli"
+
+    # info output includes expected heading
+    if ! grep -Fq -- "- INFO - | PGO CLI Support Export Tool" $CLI_LOG
+    then
+      echo "PGO CLI log does not contain expected info message"
+      eval "$CLEANUP"
+      exit 1
+    fi
+
+    # debug output includes cluster name argument
+    if ! grep -Fq -- "- DEBUG - Arg - PostgresCluster Name: kuttl-support-cluster" $CLI_LOG
+    then
+      echo "PGO CLI log does not contain cluster name debug message"
       eval "$CLEANUP"
       exit 1
     fi


### PR DESCRIPTION
This update improves the support export self-logging with timestamp information in the log file, captured arguments and flags, current Kubernetes context name and streamlined output when the command is executed.

Issue: [sc-18066]