### PR TITLE
Separate backup

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -92,7 +92,9 @@ postgresclusters/hippo backup initiated`)
 			cmd.Println(msg)
 		}
 		if err == nil {
-			// Consider a `--wait` flag
+			// Our `backup` command initiates a job, but does not signal to the user
+			// that a backup has finished; consider a `--wait` flag to wait until the
+			// backup is done.
 			cmd.Printf("%s/%s backup initiated\n", mapping.Resource.Resource, backup.ClusterName)
 		}
 

--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -22,9 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/crunchydata/postgres-operator-client/internal"
-	"github.com/crunchydata/postgres-operator-client/internal/apis/postgres-operator.crunchydata.com/v1beta1"
-	"github.com/crunchydata/postgres-operator-client/internal/testing/cmp"
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -34,6 +31,10 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/yaml"
+
+	"github.com/crunchydata/postgres-operator-client/internal"
+	"github.com/crunchydata/postgres-operator-client/internal/apis/postgres-operator.crunchydata.com/v1beta1"
+	"github.com/crunchydata/postgres-operator-client/internal/testing/cmp"
 )
 
 func TestPGBackRestBackupModifyIntent(t *testing.T) {

--- a/internal/cmd/restore_test.go
+++ b/internal/cmd/restore_test.go
@@ -174,11 +174,11 @@ spec:
 			[]byte(`{ spec: { backups: 1234 } }`), &intent.Object,
 		))
 
-		err := pgBackRestBackup{Options: []string{"a"}}.modifyIntent(&intent, now)
+		err := pgBackRestBackupArgs{Options: []string{"a"}}.modifyIntent(&intent, now)
 		assert.ErrorContains(t, err, ".spec.backups")
 		assert.ErrorContains(t, err, "is not a map")
 
-		err = pgBackRestBackup{RepoName: "b"}.modifyIntent(&intent, now)
+		err = pgBackRestBackupArgs{RepoName: "b"}.modifyIntent(&intent, now)
 		assert.ErrorContains(t, err, ".spec.backups")
 		assert.ErrorContains(t, err, "is not a map")
 	})

--- a/testing/kuttl/e2e/backup/README.md
+++ b/testing/kuttl/e2e/backup/README.md
@@ -21,6 +21,7 @@
 * Check the annotation on the cluster
 * No backup occurs
 
-(6) 10-11
+(6) 10-12
 * Update the spec through KUTTL, changing the ownership of that field
 * Call the backup CLI with different flags, and see a conflict
+* Call the backup CLI with different flags and the `--force-conflict` flag, see no conflict

--- a/testing/kuttl/e2e/backup/README.md
+++ b/testing/kuttl/e2e/backup/README.md
@@ -24,4 +24,4 @@
 (6) 10-12
 * Update the spec through KUTTL, changing the ownership of that field
 * Call the backup CLI with different flags, and see a conflict
-* Call the backup CLI with different flags and the `--force-conflict` flag, see no conflict
+* Call the backup CLI with different flags and the `--force-conflicts` flag, see no conflict


### PR DESCRIPTION
* separates out the backup logic from the cobra command
* adds a basic test to the backup command

Note: `backup` updates the cluster spec, which updates the job pod, so this command is best tested with an e2e test with a running PGO.

(The "cluster spec" is also unstructured, another reason why running an e2e test is the best way to ensure confidence.)

Issue: PGO-663