### PR TITLE
Fix postgrescluster list

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -15,7 +15,7 @@ defaultContentLanguageInSubdir= false
 enableMissingTranslationPlaceholders = false
 
 [params]
-clientVersion = "0.4.0"
+clientVersion = "0.4.1"
 
 # crunchy-hugo-theme params
 editURL = "https://github.com/CrunchyData/postgres-operator/edit/master/docs/content/"

--- a/docs/content/reference/pgo_support_export.md
+++ b/docs/content/reference/pgo_support_export.md
@@ -34,7 +34,7 @@ PostgresCluster.
     services                                            [list]
     statefulsets.apps                                   [list]
 
-    Note: This RBAC needs to be cluster-scoped to retrieve information on nodes.
+    Note: This RBAC needs to be cluster-scoped to retrieve information on nodes and postgresclusters.
 
 ### Event Capture
     Support export captures all Events in the PostgresCluster's Namespace.

--- a/docs/content/reference/pgo_version.md
+++ b/docs/content/reference/pgo_version.md
@@ -31,7 +31,7 @@ pgo version
 ```
 ### Example output
 ```
-Client Version: v0.4.0
+Client Version: v0.4.1
 Operator Version: v5.5.0
 ```
 

--- a/docs/content/releases/0.4.1.md
+++ b/docs/content/releases/0.4.1.md
@@ -1,0 +1,19 @@
+---
+title: "0.4.1"
+draft: false
+weight: 996
+---
+
+[Crunchy Postgres for Kubernetes]: https://www.crunchydata.com/products/crunchy-postgresql-for-kubernetes
+[`pgo` CLI documentation]: https://access.crunchydata.com/documentation/postgres-operator-client/latest
+
+Crunchy Data announces the release of `pgo`, Postgres Operator Client from Crunchy Data 0.4.1.
+
+Built as a `kubectl` plugin, the `pgo` CLI facilitates the creation and management of PostgreSQL clusters created using [Crunchy Postgres for Kubernetes][].
+
+For more information about using the CLI and the various commands available, please see the [`pgo` CLI documentation][].
+
+Additionally, please see the [CPK documentation](https://access.crunchydata.com/documentation/postgres-operator/latest) for information about [getting started](https://access.crunchydata.com/documentation/postgres-operator/latest/quickstart/) with Crunchy Postgres for Kubernetes.
+
+## Bug 
+- The `support export` command would fail fatally if the user didn't have permissions to list postgresclusters at the cluster-scope. This release fixes that so our postgrescluster list fails gracefully (like our other atttempts to gather Kubernetes resources).

--- a/internal/cmd/client_version.go
+++ b/internal/cmd/client_version.go
@@ -15,4 +15,4 @@
 package cmd
 
 // store the current PGO CLI version
-const clientVersion = "v0.4.0"
+const clientVersion = "v0.4.1"

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -180,7 +180,7 @@ PostgresCluster.
     services                                            [list]
     statefulsets.apps                                   [list]
 
-    Note: This RBAC needs to be cluster-scoped to retrieve information on nodes.
+    Note: This RBAC needs to be cluster-scoped to retrieve information on nodes and postgresclusters.
 
 ### Event Capture
     Support export captures all Events in the PostgresCluster's Namespace.
@@ -529,6 +529,10 @@ func gatherPostgresClusterNames(clusterName string, ctx context.Context, cmd *co
 	result, err := client.List(ctx, metav1.ListOptions{})
 
 	if err != nil {
+		if apierrors.IsForbidden(err) {
+			writeInfo(cmd, err.Error())
+			return nil
+		}
 		return err
 	}
 

--- a/internal/cmd/export.md
+++ b/internal/cmd/export.md
@@ -1,0 +1,51 @@
+## The support export command 
+
+### What is it for?
+
+The `support export` command is meant to give users a simple command to run that will produce a tar file of information that they can then use to debug or send to Crunchy Data to debug.
+
+### What are its invariants?
+
+#### Only work on one cluster at a time
+
+If the cluster doesn't exist, exit without creating a tar.
+
+#### Fail gracefully when forbidden from retrieving K8s API info
+
+If we run into an error getting info for part X, move on to part Y, Z, et al. _while_ also surfacing the error.
+
+### What does it do (in order)?
+
+* Check postgrescluster exists (fail hard)
+* Create output tar file & defer close
+* Gather CLI version (from code)
+* Get all postgrescluster names
+* Get Kubernetes context (fail hard)
+* Get server version (fail hard)
+* Gather node info
+* Gather namespace info
+* Write cluster spec (gotten in step 1)
+* Gather namespaced resources for cluster:
+  * statefulsets
+  * deployments
+  * replicasets
+  * jobs
+  * cronjobs
+  * poddisruptionbudgets
+  * pods
+  * persistentvolumeclaims
+  * configmaps
+  * services
+  * endpoints
+  * serviceaccounts
+  * ingresses
+  * limitranges
+* Gather events
+* Gather logs
+* Gather postgresql logs
+* Get monitoring logs
+* Gather patroni info
+* Gather pgBackRest info
+* Gather process info
+* Gather system time
+* Gather list of kubectl plugins


### PR DESCRIPTION
Bug: postgrescluster listing would cause support export to fail fatally. This updates that to behave like our other K8s resouce-retrievals, i.e., fail gracefully by surfacing the error but continue.

Issue: [PGO-821]