### PR TITLE
Allow user to get version without a server

### DIFF
--- a/docs/content/reference/pgo_version.md
+++ b/docs/content/reference/pgo_version.md
@@ -38,7 +38,8 @@ Operator Version: v5.5.0
 ### Options
 
 ```
-  -h, --help   help for version
+      --client   If true, shows client version only (no server required).
+  -h, --help     help for version
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -47,6 +47,9 @@ func newVersionCommand(config *internal.Config) *cobra.Command {
 	// No arguments for 'version'
 	cmd.Args = cobra.NoArgs
 
+	var clientOnly bool
+	cmd.Flags().BoolVar(&clientOnly, "client", false, "If true, shows client version only (no server required).")
+
 	cmd.Example = internal.FormatExample(fmt.Sprintf(`# Request the version of the client and the operator
 pgo version
 
@@ -57,6 +60,9 @@ Operator Version: v5.5.0`, clientVersion))
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 
 		cmd.Printf("Client Version: %s\n", clientVersion)
+		if clientOnly {
+			return nil
+		}
 
 		ctx := context.Background()
 		restConfig, err := config.ToRESTConfig()

--- a/testing/kuttl/e2e/version/00--check-version.yaml
+++ b/testing/kuttl/e2e/version/00--check-version.yaml
@@ -6,7 +6,8 @@ commands:
 
     VERSION_OUTPUT=$(kubectl pgo version)
     { contains "${VERSION_OUTPUT}" "Client Version:"; } || {
-      echo ${VERSION_OUTPUT}
+      echo "Expected: Client Version:*"
+      echo "Actual: ${VERSION_OUTPUT}"
       exit 1
     }
 - script: |
@@ -20,7 +21,7 @@ commands:
     VERSION_OUTPUT=$(kubectl pgo version)
 
     { contains "${VERSION_OUTPUT}" "Operator Version: v${OPERATOR_VERSION}"; } || {
-      echo ${VERSION_OUTPUT}
-      echo ${OPERATOR_VERSION}
+      echo "Expected: ${OPERATOR_VERSION}"
+      echo "Actual: ${VERSION_OUTPUT}"
       exit 1
     }

--- a/testing/kuttl/e2e/version/00--check-version.yaml
+++ b/testing/kuttl/e2e/version/00--check-version.yaml
@@ -2,25 +2,16 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+
     VERSION_OUTPUT=$(kubectl pgo version)
-    CLI_VERSION=$(kubectl pgo version | awk '{print $3}')
-
-    # the CLI version isn't empty and the CLI version output follows the expected format
-    if [ -z "$CLI_VERSION" ]; then
-      echo "Client version output is empty."
+    { contains "${VERSION_OUTPUT}" "Client Version:"; } || {
+      echo ${VERSION_OUTPUT}
       exit 1
-    fi
-
-    case "${VERSION_OUTPUT}" in
-    *"Client Version: "*)
-        ;;
-    *)
-        echo "Version output is: "
-        echo "$VERSION_OUTPUT"
-        exit 1
-        ;;
-    esac
+    }
 - script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+
     OPERATOR_VERSION=$(
         kubectl get crd postgresclusters.postgres-operator.crunchydata.com \
           -o go-template='{{ index .metadata.labels "app.kubernetes.io/version" }}'
@@ -28,19 +19,8 @@ commands:
 
     VERSION_OUTPUT=$(kubectl pgo version)
 
-    # the operator version isn't empty and the version output matches the CRD value
-    if [ -z "$OPERATOR_VERSION" ]; then
-      echo "Operator version output is empty."
+    { contains "${VERSION_OUTPUT}" "Operator Version: v${OPERATOR_VERSION}"; } || {
+      echo ${VERSION_OUTPUT}
+      echo ${OPERATOR_VERSION}
       exit 1
-    fi
-
-    case "${VERSION_OUTPUT}" in
-    *"Operator Version: v$OPERATOR_VERSION"*)
-        ;;
-    *)
-        echo "Version output is: "
-        echo "$VERSION_OUTPUT"
-        echo "Expected: v$OPERATOR_VERSION"
-        exit 1
-        ;;
-    esac
+    }

--- a/testing/kuttl/e2e/version/01--check-client-version.yaml
+++ b/testing/kuttl/e2e/version/01--check-client-version.yaml
@@ -9,6 +9,7 @@ commands:
     VERSION_OUTPUT=$(KUBECONFIG=blah kubectl pgo version --client)
 
     { contains "${VERSION_OUTPUT}" "Client Version:"; } || {
-      echo ${VERSION_OUTPUT}
+      echo "Expected: Client Version:*"
+      echo "Actual: ${VERSION_OUTPUT}"
       exit 1
     }

--- a/testing/kuttl/e2e/version/01--check-client-version.yaml
+++ b/testing/kuttl/e2e/version/01--check-client-version.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+# The following test should check that the client version output is returned
+# when a kubernetes cluster is not available
+- script: |
+    contains() { bash -ceu '[[ "$1" == *"$2"* ]]' - "$@"; }
+
+    VERSION_OUTPUT=$(KUBECONFIG=blah kubectl pgo version --client)
+
+    { contains "${VERSION_OUTPUT}" "Client Version:"; } || {
+      echo ${VERSION_OUTPUT}
+      exit 1
+    }


### PR DESCRIPTION
If you don't have a running server, the current version command will fail.
```
$ KUBECONFIG=blah ./bin/kubectl-pgo version
Client Version: v0.4.1
W0123 12:49:15.331122 1788689 loader.go:221] Config not found: blah
Error: Get "http://localhost:8080/apis/apiextensions.k8s.io/v1/customresourcedefinitions/postgresclusters.postgres-operator.crunchydata.com": dial tcp 127.0.0.1:8080: connect: connection refused
$ echo $?
1
```
With the change, you can pass the `--client` or `--client=true` flag to skip the server and postgrescluster version check
```
$ KUBECONFIG=blah ./bin/kubectl-pgo version --client
Client Version: v0.4.1
$ echo $?
0
```
