### PR TITLE
More support export logs

### DIFF
--- a/internal/cmd/client_version.go
+++ b/internal/cmd/client_version.go
@@ -15,4 +15,4 @@
 package cmd
 
 // store the current PGO CLI version
-const clientVersion = "v0.4.2"
+const clientVersion = "v0.4.3"

--- a/internal/cmd/client_version.go
+++ b/internal/cmd/client_version.go
@@ -15,4 +15,4 @@
 package cmd
 
 // store the current PGO CLI version
-const clientVersion = "v0.4.3"
+const clientVersion = "v0.4.2"

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -49,6 +49,39 @@ func (exec Executor) listPGLogFiles(numLogs int) (string, string, error) {
 	return stdout.String(), stderr.String(), err
 }
 
+// listPGConfFiles returns the full path of Postgres conf files.
+// These are the *.conf stored on the Postgres instance
+func (exec Executor) listPGConfFiles() (string, string, error) {
+	var stdout, stderr bytes.Buffer
+
+	command := "ls -1dt pgdata/pg[0-9][0-9]/*.conf"
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+
+	return stdout.String(), stderr.String(), err
+}
+
+// listBackrestLogFiles returns the full path of pgBackRest log files.
+// These are the pgBackRest logs stored on the Postgres instance
+func (exec Executor) listBackrestLogFiles() (string, string, error) {
+	var stdout, stderr bytes.Buffer
+
+	command := "ls -1dt pgdata/pgbackrest/log/*"
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+
+	return stdout.String(), stderr.String(), err
+}
+
+// listBackrestRepoHostLogFiles returns the full path of pgBackRest log files.
+// These are the pgBackRest logs stored on the repo host
+func (exec Executor) listBackrestRepoHostLogFiles() (string, string, error) {
+	var stdout, stderr bytes.Buffer
+
+	command := "ls -1dt pgbackrest/*/log/*"
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+
+	return stdout.String(), stderr.String(), err
+}
+
 // catFile takes the full path of a file and returns the contents
 // of that file
 func (exec Executor) catFile(filePath string) (string, string, error) {

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -997,8 +997,10 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		// Get Postgres Log Files
 		stdout, stderr, err := Executor(exec).listPGLogFiles(numLogs)
 
-		// Depending upon the list* function above, err may be non-nil or stderr may
-		// be non-empty, indicating an error has happened.
+		// Depending upon the list* function above:
+		// An error may happen when err is non-nil or stderr is non-empty.
+		// In both cases, we want to print helpful information and continue to the
+		// next iteration.
 		if err != nil || stderr != "" {
 
 			if apierrors.IsForbidden(err) {
@@ -1007,6 +1009,14 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 			}
 
 			writeDebug(cmd, "Error getting PG logs\n")
+
+			if err != nil {
+				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
+			}
+			if stderr != "" {
+				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+			}
+
 			if strings.Contains(stderr, "No such file or directory") {
 				writeDebug(cmd, "Cannot find any Postgres log files. This is acceptable in some configurations.\n")
 			}
@@ -1043,15 +1053,31 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 
 		// Get Postgres Conf Files
 		stdout, stderr, err = Executor(exec).listPGConfFiles()
-		if err != nil {
+
+		// Depending upon the list* function above:
+		// An error may happen when err is non-nil or stderr is non-empty.
+		// In both cases, we want to print helpful information and continue to the
+		// next iteration.
+		if err != nil || stderr != "" {
+
 			if apierrors.IsForbidden(err) {
 				writeInfo(cmd, err.Error())
 				return nil
 			}
-			return err
-		}
-		if stderr != "" {
-			writeInfo(cmd, stderr)
+
+			writeDebug(cmd, "Error getting PG Conf files\n")
+
+			if err != nil {
+				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
+			}
+			if stderr != "" {
+				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+			}
+
+			if strings.Contains(stderr, "No such file or directory") {
+				writeDebug(cmd, "Cannot find any PG Conf files. This is acceptable in some configurations.\n")
+			}
+			continue
 		}
 
 		logFiles = strings.Split(strings.TrimSpace(stdout), "\n")
@@ -1133,8 +1159,10 @@ func gatherDbBackrestLogs(ctx context.Context,
 		// Get pgBackRest Log Files
 		stdout, stderr, err := Executor(exec).listBackrestLogFiles()
 
-		// Depending upon the list* function above, err may be non-nil or stderr may
-		// be non-empty, indicating an error has happened.
+		// Depending upon the list* function above:
+		// An error may happen when err is non-nil or stderr is non-empty.
+		// In both cases, we want to print helpful information and continue to the
+		// next iteration.
 		if err != nil || stderr != "" {
 
 			if apierrors.IsForbidden(err) {
@@ -1143,6 +1171,14 @@ func gatherDbBackrestLogs(ctx context.Context,
 			}
 
 			writeDebug(cmd, "Error getting pgBackRest logs\n")
+
+			if err != nil {
+				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
+			}
+			if stderr != "" {
+				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+			}
+
 			if strings.Contains(stderr, "No such file or directory") {
 				writeDebug(cmd, "Cannot find any pgBackRest log files. This is acceptable in some configurations.\n")
 			}
@@ -1228,8 +1264,10 @@ func gatherRepoHostLogs(ctx context.Context,
 		// Get BackRest Repo Host Log Files
 		stdout, stderr, err := Executor(exec).listBackrestRepoHostLogFiles()
 
-		// Depending upon the list* function above, err may be non-nil or stderr may
-		// be non-empty, indicating an error has happened.
+		// Depending upon the list* function above:
+		// An error may happen when err is non-nil or stderr is non-empty.
+		// In both cases, we want to print helpful information and continue to the
+		// next iteration.
 		if err != nil || stderr != "" {
 
 			if apierrors.IsForbidden(err) {
@@ -1238,6 +1276,14 @@ func gatherRepoHostLogs(ctx context.Context,
 			}
 
 			writeDebug(cmd, "Error getting pgBackRest logs\n")
+
+			if err != nil {
+				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
+			}
+			if stderr != "" {
+				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+			}
+
 			if strings.Contains(stderr, "No such file or directory") {
 				writeDebug(cmd, "Cannot find any pgBackRest log files. This is acceptable in some configurations.\n")
 			}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -980,13 +980,13 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 
 	writeDebug(cmd, fmt.Sprintf("Found %d Pods\n", len(dbPods.Items)))
 
+	podExec, err := util.NewPodExecutor(config)
+	if err != nil {
+		return err
+	}
+
 	for _, pod := range dbPods.Items {
 		writeDebug(cmd, fmt.Sprintf("Pod Name is %s\n", pod.Name))
-
-		podExec, err := util.NewPodExecutor(config)
-		if err != nil {
-			return err
-		}
 
 		exec := func(stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
@@ -996,18 +996,20 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 
 		// Get Postgres Log Files
 		stdout, stderr, err := Executor(exec).listPGLogFiles(numLogs)
-		if err != nil {
-			if strings.Contains(stderr, "No such file or directory") {
-				writeDebug(cmd, "Cannot find any Postgres log files. This is acceptable in some configurations.\n")
-			}
+
+		// Depending upon the list* function above, err may be non-nil or stderr may
+		// be non-empty, indicating an error has happened.
+		if err != nil || stderr != "" {
+
 			if apierrors.IsForbidden(err) {
 				writeInfo(cmd, err.Error())
 				return nil
 			}
-			continue
-		}
-		if stderr != "" {
-			writeDebug(cmd, stderr)
+
+			writeDebug(cmd, "Error getting PG logs\n")
+			if strings.Contains(stderr, "No such file or directory") {
+				writeDebug(cmd, "Cannot find any Postgres log files. This is acceptable in some configurations.\n")
+			}
 			continue
 		}
 
@@ -1114,13 +1116,13 @@ func gatherDbBackrestLogs(ctx context.Context,
 
 	writeDebug(cmd, fmt.Sprintf("Found %d Pods\n", len(dbPods.Items)))
 
+	podExec, err := util.NewPodExecutor(config)
+	if err != nil {
+		return err
+	}
+
 	for _, pod := range dbPods.Items {
 		writeDebug(cmd, fmt.Sprintf("Pod Name is %s\n", pod.Name))
-
-		podExec, err := util.NewPodExecutor(config)
-		if err != nil {
-			return err
-		}
 
 		exec := func(stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
@@ -1130,18 +1132,20 @@ func gatherDbBackrestLogs(ctx context.Context,
 
 		// Get pgBackRest Log Files
 		stdout, stderr, err := Executor(exec).listBackrestLogFiles()
-		if err != nil {
-			if strings.Contains(stderr, "No such file or directory") {
-				writeDebug(cmd, "Cannot find any Backrest log files. This is acceptable in some configurations.\n")
-			}
+
+		// Depending upon the list* function above, err may be non-nil or stderr may
+		// be non-empty, indicating an error has happened.
+		if err != nil || stderr != "" {
+
 			if apierrors.IsForbidden(err) {
 				writeInfo(cmd, err.Error())
 				return nil
 			}
-			continue
-		}
-		if stderr != "" {
-			writeDebug(cmd, stderr)
+
+			writeDebug(cmd, "Error getting pgBackRest logs\n")
+			if strings.Contains(stderr, "No such file or directory") {
+				writeDebug(cmd, "Cannot find any pgBackRest log files. This is acceptable in some configurations.\n")
+			}
 			continue
 		}
 
@@ -1207,13 +1211,13 @@ func gatherRepoHostLogs(ctx context.Context,
 
 	writeDebug(cmd, fmt.Sprintf("Found %d Repo Host Pod\n", len(repoHostPods.Items)))
 
+	podExec, err := util.NewPodExecutor(config)
+	if err != nil {
+		return err
+	}
+
 	for _, pod := range repoHostPods.Items {
 		writeDebug(cmd, fmt.Sprintf("Pod Name is %s\n", pod.Name))
-
-		podExec, err := util.NewPodExecutor(config)
-		if err != nil {
-			return err
-		}
 
 		exec := func(stdin io.Reader, stdout, stderr io.Writer, command ...string,
 		) error {
@@ -1223,18 +1227,20 @@ func gatherRepoHostLogs(ctx context.Context,
 
 		// Get BackRest Repo Host Log Files
 		stdout, stderr, err := Executor(exec).listBackrestRepoHostLogFiles()
-		if err != nil {
-			if strings.Contains(stderr, "No such file or directory") {
-				writeDebug(cmd, "Cannot find any Repo Host log files. This is acceptable in some configurations.\n")
-			}
+
+		// Depending upon the list* function above, err may be non-nil or stderr may
+		// be non-empty, indicating an error has happened.
+		if err != nil || stderr != "" {
+
 			if apierrors.IsForbidden(err) {
 				writeInfo(cmd, err.Error())
 				return nil
 			}
-			continue
-		}
-		if stderr != "" {
-			writeDebug(cmd, stderr)
+
+			writeDebug(cmd, "Error getting pgBackRest logs\n")
+			if strings.Contains(stderr, "No such file or directory") {
+				writeDebug(cmd, "Cannot find any pgBackRest log files. This is acceptable in some configurations.\n")
+			}
 			continue
 		}
 

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -527,7 +527,7 @@ Collecting PGO CLI logs...
 
 		// Print cli output
 		writeInfo(cmd, "Collecting PGO CLI logs...")
-		path := clusterName + "/logs/cli"
+		path := clusterName + "/cli.log"
 		if logErr := writeTar(tw, cliOutput.Bytes(), path, cmd); logErr != nil {
 			return logErr
 		}
@@ -1033,7 +1033,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 				buf.Write([]byte(str))
 			}
 
-			path := clusterName + fmt.Sprintf("/logs/%s/", pod.Name) + logFile
+			path := clusterName + fmt.Sprintf("/pods/%s/", pod.Name) + logFile
 			if err := writeTar(tw, buf.Bytes(), path, cmd); err != nil {
 				return err
 			}
@@ -1073,7 +1073,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 				buf.Write([]byte(str))
 			}
 
-			path := clusterName + fmt.Sprintf("/logs/%s/", pod.Name) + logFile
+			path := clusterName + fmt.Sprintf("/pods/%s/", pod.Name) + logFile
 			if err := writeTar(tw, buf.Bytes(), path, cmd); err != nil {
 				return err
 			}
@@ -1167,7 +1167,7 @@ func gatherDbBackrestLogs(ctx context.Context,
 				buf.Write([]byte(str))
 			}
 
-			path := clusterName + fmt.Sprintf("/logs/%s/", pod.Name) + logFile
+			path := clusterName + fmt.Sprintf("/pods/%s/", pod.Name) + logFile
 			if err := writeTar(tw, buf.Bytes(), path, cmd); err != nil {
 				return err
 			}
@@ -1260,7 +1260,7 @@ func gatherRepoHostLogs(ctx context.Context,
 				buf.Write([]byte(str))
 			}
 
-			path := clusterName + fmt.Sprintf("/logs/%s/", pod.Name) + logFile
+			path := clusterName + fmt.Sprintf("/pods/%s/", pod.Name) + logFile
 			if err := writeTar(tw, buf.Bytes(), path, cmd); err != nil {
 				return err
 			}
@@ -1322,7 +1322,7 @@ func gatherPodLogs(ctx context.Context,
 				return err
 			}
 
-			path := rootDir + "/logs/" +
+			path := rootDir + "/pods/" +
 				pod.GetName() + "/containers/" + container.Name + ".log"
 			if err := writeTar(tw, b, path, cmd); err != nil {
 				return err

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1014,7 +1014,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 			}
 			if stderr != "" {
-				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+				writeDebug(cmd, stderr)
 			}
 
 			if strings.Contains(stderr, "No such file or directory") {
@@ -1071,7 +1071,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 			}
 			if stderr != "" {
-				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+				writeDebug(cmd, stderr)
 			}
 
 			if strings.Contains(stderr, "No such file or directory") {
@@ -1176,7 +1176,7 @@ func gatherDbBackrestLogs(ctx context.Context,
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 			}
 			if stderr != "" {
-				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+				writeDebug(cmd, stderr)
 			}
 
 			if strings.Contains(stderr, "No such file or directory") {

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1281,7 +1281,7 @@ func gatherRepoHostLogs(ctx context.Context,
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 			}
 			if stderr != "" {
-				writeDebug(cmd, fmt.Sprintf("%s", stderr))
+				writeDebug(cmd, stderr)
 			}
 
 			if strings.Contains(stderr, "No such file or directory") {

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -948,8 +948,8 @@ func gatherEvents(ctx context.Context,
 	return nil
 }
 
-// gatherPostgresLogsAndConfigs take a client and writes logs from primary and replicas
-// to a buffer
+// gatherPostgresLogsAndConfigs take a client and writes logs and configs
+// from primary and replicas to a buffer
 func gatherPostgresLogsAndConfigs(ctx context.Context,
 	clientset *kubernetes.Clientset,
 	config *rest.Config,

--- a/internal/cmd/show.go
+++ b/internal/cmd/show.go
@@ -95,7 +95,7 @@ HA
 		if stdout, stderr, err := getBackup(config, args, "text", ""); err != nil {
 			return err
 		} else {
-			cmd.Printf(stdout)
+			cmd.Printf("%s", stdout)
 			if stderr != "" {
 				cmd.Printf("\nError returned: %s\n", stderr)
 			}
@@ -106,7 +106,7 @@ HA
 		if stdout, stderr, err := getHA(config, args, "pretty"); err != nil {
 			return err
 		} else {
-			cmd.Printf(stdout)
+			cmd.Printf("%s", stdout)
 			if stderr != "" {
 				cmd.Printf("\nError returned: %s\n", stderr)
 			}
@@ -185,7 +185,7 @@ stanza: db
 		stdout, stderr, err := getBackup(config, args, outputEnum.String(), repoNum)
 
 		if err == nil {
-			cmd.Printf(stdout)
+			cmd.Printf("%s", stdout)
 			if stderr != "" {
 				cmd.Printf("\nError returned: %s\n", stderr)
 			}
@@ -257,7 +257,7 @@ pgo show ha hippo --output json
 		stdout, stderr, err := getHA(config, args, outputEnum.String())
 
 		if err == nil {
-			cmd.Printf(stdout)
+			cmd.Printf("%s", stdout)
 			if stderr != "" {
 				cmd.Printf("\nError returned: %s\n", stderr)
 			}

--- a/internal/cmd/stop.go
+++ b/internal/cmd/stop.go
@@ -91,7 +91,7 @@ postgresclusters/hippo stop initiated`)
 
 		msg, err := patchClusterShutdown(cluster, client, requestArgs)
 		if msg != "" {
-			cmd.Printf(msg)
+			cmd.Printf("%s", msg)
 		}
 		if err != nil {
 			return err

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -41,6 +41,9 @@ const (
 
 	// DataPostgres is a LabelData value that indicates the object has PostgreSQL data.
 	DataPostgres = "postgres"
+
+	// DataBackrest is a LabelData value that indicate the object is a Repo Host.
+	DataBackrest = "pgbackrest"
 )
 
 const (
@@ -49,6 +52,10 @@ const (
 	// RolePatroniLeader is the LabelRole that Patroni sets on the Pod that is
 	// currently the leader.
 	RolePatroniLeader = "master"
+
+	// RolePatroniReplica is the LabelRole that Patroni sets on the Pod that is
+	// currently a replica.
+	RolePatroniReplica = "replica"
 
 	// RolePostgresUser is the LabelRole applied to PostgreSQL user secrets.
 	RolePostgresUser = "pguser"
@@ -60,6 +67,8 @@ const (
 	// ContainerDatabase is the name of the container running PostgreSQL and
 	// supporting tools: Patroni, pgBackRest, etc.
 	ContainerDatabase = "database"
+
+	ContainerPGBackrest = "pgbackrest"
 )
 
 // PrimaryInstanceLabels provides labels for a PostgreSQL cluster primary instance
@@ -67,6 +76,19 @@ func PrimaryInstanceLabels(clusterName string) string {
 	return LabelCluster + "=" + clusterName + "," +
 		LabelData + "=" + DataPostgres + "," +
 		LabelRole + "=" + RolePatroniLeader
+}
+
+// ReplicaInstanceLabels provides labels for a PostgreSQL cluster replica instances
+func ReplicaInstanceLabels(clusterName string) string {
+	return LabelCluster + "=" + clusterName + "," +
+		LabelData + "=" + DataPostgres + "," +
+		LabelRole + "=" + RolePatroniReplica
+}
+
+// RepoHostInstanceLabels provides labels for a Backrest Repo Host instances
+func RepoHostInstanceLabels(clusterName string) string {
+	return LabelCluster + "=" + clusterName + "," +
+		LabelData + "=" + DataBackrest
 }
 
 // PostgresUserSecretLabels provides labels for the Postgres user Secret

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -34,6 +34,9 @@ const (
 
 	// LabelOperator is used to identify operator Pods
 	LabelOperator = "postgres-operator.crunchydata.com/control-plane"
+
+	// LabelPGBackRestDedicated is used to identify the Repo Host pod
+	LabelPGBackRestDedicated = labelPrefix + "pgbackrest-dedicated"
 )
 
 const (
@@ -87,7 +90,7 @@ func PrimaryInstanceLabels(clusterName string) string {
 // RepoHostInstanceLabels provides labels for a Backrest Repo Host instances
 func RepoHostInstanceLabels(clusterName string) string {
 	return LabelCluster + "=" + clusterName + "," +
-		LabelData + "=" + DataBackrest
+		LabelPGBackRestDedicated + "="
 }
 
 // PostgresUserSecretLabels provides labels for the Postgres user Secret

--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -71,18 +71,17 @@ const (
 	ContainerPGBackrest = "pgbackrest"
 )
 
+// DBInstanceLabels provides labels for a PostgreSQL cluster primary or replica instance
+func DBInstanceLabels(clusterName string) string {
+	return LabelCluster + "=" + clusterName + "," +
+		LabelData + "=" + DataPostgres
+}
+
 // PrimaryInstanceLabels provides labels for a PostgreSQL cluster primary instance
 func PrimaryInstanceLabels(clusterName string) string {
 	return LabelCluster + "=" + clusterName + "," +
 		LabelData + "=" + DataPostgres + "," +
 		LabelRole + "=" + RolePatroniLeader
-}
-
-// ReplicaInstanceLabels provides labels for a PostgreSQL cluster replica instances
-func ReplicaInstanceLabels(clusterName string) string {
-	return LabelCluster + "=" + clusterName + "," +
-		LabelData + "=" + DataPostgres + "," +
-		LabelRole + "=" + RolePatroniReplica
 }
 
 // RepoHostInstanceLabels provides labels for a Backrest Repo Host instances

--- a/testing/kuttl/e2e/support-export/01--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/01--support_export.yaml
@@ -128,7 +128,7 @@ commands:
     fi
 
     # check that the PGO CLI log file contains expected messages
-    CLI_LOG="./kuttl-support-cluster/logs/cli"
+    CLI_LOG="./kuttl-support-cluster/cli.log"
 
     # info output includes expected heading
     if ! grep -Fq -- "- INFO - | PGO CLI Support Export Tool" $CLI_LOG

--- a/testing/kuttl/e2e/support-export/31--support_export.yaml
+++ b/testing/kuttl/e2e/support-export/31--support_export.yaml
@@ -6,8 +6,8 @@ commands:
 - script: tar -xzf ./crunchy_k8s_support_export_*.tar.gz
 - script: |
     CLEANUP="rm -r ./kuttl-support-monitoring-cluster ./monitoring ./crunchy_k8s_support_export_*.tar.gz"
-    CLUSTER_DIR="./kuttl-support-monitoring-cluster/logs/"
-    MONITORING_DIR="./monitoring/logs/"
+    CLUSTER_DIR="./kuttl-support-monitoring-cluster/pods/"
+    MONITORING_DIR="./monitoring/pods/"
 
     # check for exporter, prometheus, grafana and alertmanager logs
     found=$(find ${CLUSTER_DIR} -name "*exporter.log" | wc -l)


### PR DESCRIPTION
The pgo support export feature gathers Postgres logs from replicas in addition to the primary and pgbackrest logs where appropriate (in addition to those gathered in the container logs.