### PR TITLE
Pgbackrest check and pgcontroldata

### DIFF
--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -39,6 +39,13 @@ func (exec Executor) pgBackRestInfo(output, repoNum string) (string, string, err
 	return stdout.String(), stderr.String(), err
 }
 
+// bashCommand defines a one-line bash command to exec in a container
+func (exec Executor) bashCommand(command string) (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+	return stdout.String(), stderr.String(), err
+}
+
 // pgBackRestCheck defines a pgBackRest check command
 // Force log-level-console=detail to override if set elsewhere
 func (exec Executor) pgBackRestCheck() (string, string, error) {

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -39,6 +39,16 @@ func (exec Executor) pgBackRestInfo(output, repoNum string) (string, string, err
 	return stdout.String(), stderr.String(), err
 }
 
+// pgBackRestCheck defines a pgBackRest check command
+// Force log-level-console=detail to override if set elsewhere
+func (exec Executor) pgBackRestCheck() (string, string, error) {
+	var stdout, stderr bytes.Buffer
+	command := "pgbackrest check --log-level-console=detail"
+	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
+
+	return stdout.String(), stderr.String(), err
+}
+
 // postgresqlListLogFiles returns the full path of numLogs log files.
 func (exec Executor) listPGLogFiles(numLogs int) (string, string, error) {
 	var stdout, stderr bytes.Buffer

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1115,19 +1115,19 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		}
 
 		commands := []Command{
-			{Path: "pg_controldata", description: "pg_controldata"},
+			{path: "pg_controldata", description: "pg_controldata"},
 		}
 
 		var buf bytes.Buffer
 
 		for _, command := range commands {
-			stdout, stderr, err := Executor(exec).bashCommand(command.Path)
+			stdout, stderr, err := Executor(exec).bashCommand(command.path)
 			if err != nil {
 				if apierrors.IsForbidden(err) {
 					writeInfo(cmd, err.Error())
 					return nil
 				}
-				writeDebug(cmd, fmt.Sprintf("Error executing %s\n", command.Path))
+				writeDebug(cmd, fmt.Sprintf("Error executing %s\n", command.path))
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 				writeDebug(cmd, "This is acceptable in some configurations.\n")
 				continue

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1108,22 +1108,28 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		}
 
 		// We will execute several bash commands in the DB container
-		commands := []string{
-			"pg_controldata",
-			"df -h /pgdata",
-			"du -h /pgdata | expand",
-			"df -h /pgwal",
-			"du -h /pgwal | expand",
-			"df -h /tablespaces",
-			"du -h /tablespaces | expand",
-			"ls /pg*/pg*_wal/archive_status/* | grep -E '*.ready' | wc",
-			"ls /pg*/pg*_wal/archive_status/* | grep -E '*.done' | wc",
+		// text is command to execute and desc is a short description
+		type Command struct {
+			text string
+			desc string
+		}
+
+		commands := []Command{
+			{text: "pg_controldata", desc: "pg_controldata"},
+			{text: "df -h /pgdata", desc: "df /pgdata"},
+			{text: "du -h /pgdata | expand", desc: "du /pgdata"},
+			{text: "df -h /pgwal", desc: "df /pgwal"},
+			{text: "du -h /pgwal | expand", desc: "du /pgwal"},
+			{text: "df -h /tablespaces", desc: "df /tablespaces"},
+			{text: "du -h /tablespaces | expand", desc: "du /tablespaces"},
+			{text: "ls /pg*/pg*_wal/archive_status/* | grep -E '*.ready' | wc", desc: "archive_status/*.ready files"},
+			{text: "ls /pg*/pg*_wal/archive_status/* | grep -E '*.done' | wc", desc: "archive_status/*.done files"},
 		}
 
 		var buf bytes.Buffer
 
 		for _, command := range commands {
-			stdout, stderr, err := Executor(exec).bashCommand(command)
+			stdout, stderr, err := Executor(exec).bashCommand(command.text)
 			if err != nil {
 				if apierrors.IsForbidden(err) {
 					writeInfo(cmd, err.Error())
@@ -1134,7 +1140,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 				writeDebug(cmd, "This is acceptable in some configurations.\n")
 				continue
 			}
-			buf.Write([]byte(fmt.Sprintf("%s\n", command)))
+			buf.Write([]byte(fmt.Sprintf("%s\n", command.desc)))
 			buf.Write([]byte(stdout))
 			if stderr != "" {
 				buf.Write([]byte(stderr))

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1110,29 +1110,29 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		// We will execute several bash commands in the DB container
 		// text is command to execute and desc is a short description
 		type Command struct {
-			text string
-			desc string
+			Path        string
+			description string
 		}
 
 		commands := []Command{
-			{text: "pg_controldata", desc: "pg_controldata"},
+			{Path: "pg_controldata", description: "pg_controldata"},
 		}
 
 		var buf bytes.Buffer
 
 		for _, command := range commands {
-			stdout, stderr, err := Executor(exec).bashCommand(command.text)
+			stdout, stderr, err := Executor(exec).bashCommand(command.Path)
 			if err != nil {
 				if apierrors.IsForbidden(err) {
 					writeInfo(cmd, err.Error())
 					return nil
 				}
-				writeDebug(cmd, fmt.Sprintf("Error executing %s\n", command.text))
+				writeDebug(cmd, fmt.Sprintf("Error executing %s\n", command.Path))
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 				writeDebug(cmd, "This is acceptable in some configurations.\n")
 				continue
 			}
-			buf.Write([]byte(fmt.Sprintf("%s\n", command.desc)))
+			buf.Write([]byte(fmt.Sprintf("%s\n", command.description)))
 			buf.Write([]byte(stdout))
 			if stderr != "" {
 				buf.Write([]byte(stderr))

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1116,14 +1116,6 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 
 		commands := []Command{
 			{text: "pg_controldata", desc: "pg_controldata"},
-			{text: "df -h /pgdata", desc: "df /pgdata"},
-			{text: "du -h /pgdata | expand", desc: "du /pgdata"},
-			{text: "df -h /pgwal", desc: "df /pgwal"},
-			{text: "du -h /pgwal | expand", desc: "du /pgwal"},
-			{text: "df -h /tablespaces", desc: "df /tablespaces"},
-			{text: "du -h /tablespaces | expand", desc: "du /tablespaces"},
-			{text: "ls /pg*/pg*_wal/archive_status/* | grep -E '*.ready' | wc", desc: "archive_status/*.ready files"},
-			{text: "ls /pg*/pg*_wal/archive_status/* | grep -E '*.done' | wc", desc: "archive_status/*.done files"},
 		}
 
 		var buf bytes.Buffer

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1111,11 +1111,11 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		commands := []string{
 			"pg_controldata",
 			"df -h /pgdata",
-			"du -h /pgdata",
+			"du -h /pgdata | expand",
 			"df -h /pgwal",
-			"du -h /pgwal",
+			"du -h /pgwal | expand",
 			"df -h /tablespaces",
-			"du -h /tablespaces",
+			"du -h /tablespaces | expand",
 			"ls /pg*/pg*_wal/archive_status/* | grep -E '*.ready' | wc",
 			"ls /pg*/pg*_wal/archive_status/* | grep -E '*.done' | wc",
 		}
@@ -1123,7 +1123,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		var buf bytes.Buffer
 
 		for _, command := range commands {
-			stdout, stderr, err = Executor(exec).bashCommand(command)
+			stdout, stderr, err := Executor(exec).bashCommand(command)
 			if err != nil {
 				if apierrors.IsForbidden(err) {
 					writeInfo(cmd, err.Error())

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1110,7 +1110,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		// We will execute several bash commands in the DB container
 		// text is command to execute and desc is a short description
 		type Command struct {
-			Path        string
+			path        string
 			description string
 		}
 

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1135,7 +1135,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 					writeInfo(cmd, err.Error())
 					return nil
 				}
-				writeDebug(cmd, fmt.Sprintf("Error executing %s\n", command))
+				writeDebug(cmd, fmt.Sprintf("Error executing %s\n", command.text))
 				writeDebug(cmd, fmt.Sprintf("%s\n", err.Error()))
 				writeDebug(cmd, "This is acceptable in some configurations.\n")
 				continue

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1141,7 +1141,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 		}
 
 		// Write the buffer to a file
-		path := clusterName + fmt.Sprintf("/pods/%s/", pod.Name) + "postgres-info"
+		path := clusterName + fmt.Sprintf("/pods/%s/%s", pod.Name, "postgres-info")
 		if err := writeTar(tw, buf.Bytes(), path, cmd); err != nil {
 			return err
 		}

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1518,6 +1518,21 @@ func gatherPgBackRestInfo(ctx context.Context,
 		buf.Write([]byte(stderr))
 	}
 
+	buf.Write([]byte("pgbackrest check\n"))
+	stdout, stderr, err = Executor(exec).pgBackRestCheck()
+	if err != nil {
+		if apierrors.IsForbidden(err) {
+			writeInfo(cmd, err.Error())
+			return nil
+		}
+		return err
+	}
+
+	buf.Write([]byte(stdout))
+	if stderr != "" {
+		buf.Write([]byte(stderr))
+	}
+
 	path := clusterName + "/pgbackrest-info"
 	return writeTar(tw, buf.Bytes(), path, cmd)
 }


### PR DESCRIPTION
This is an update to the Support Export.

- Add `pgbackrest check` to the `pgbackrest-info` file for the entire cluster
- Add `pg_controldata` output to the `postgres-info` file for each Pod

There are other bash commands that could be added along `pg_controldata` but those features are still under discussion.