### PR TITLE
Large postgres logs

### DIFF
--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 )
 
 // Executor calls commands
@@ -108,6 +109,13 @@ func (exec Executor) catFile(filePath string) (string, string, error) {
 	err := exec(nil, &stdout, &stderr, "bash", "-ceu", "--", command)
 
 	return stdout.String(), stderr.String(), err
+}
+
+func (exec Executor) copyFile(source string, destination *os.File) (string, error) {
+	var stderr bytes.Buffer
+	command := fmt.Sprintf("cat %s", source)
+	err := exec(nil, destination, &stderr, "bash", "-ceu", "--", command)
+	return stderr.String(), err
 }
 
 // patronictl takes a patronictl subcommand and returns the output of that command

--- a/internal/cmd/exec.go
+++ b/internal/cmd/exec.go
@@ -111,6 +111,8 @@ func (exec Executor) catFile(filePath string) (string, string, error) {
 	return stdout.String(), stderr.String(), err
 }
 
+// copyFile takes the full path of a file and a local destination to save the
+// file on disk
 func (exec Executor) copyFile(source string, destination *os.File) (string, error) {
 	var stderr bytes.Buffer
 	command := fmt.Sprintf("cat %s", source)

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1053,7 +1053,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 			// e.g. postgres-operator/hippo-instance1-vp9k-0:pgdata/pg16/log/postgresql-Tue.log
 			fileSpecSrc := fmt.Sprintf("%s/%s:%s", namespace, pod.Name, logFile)
 			fileSpecDest := filepath.Join(localDirectory, logFile)
-			writeInfo(cmd, fmt.Sprintf("\tSize of %-85s %v", fileSpecSrc, ConvertBytes(fileSize)))
+			writeInfo(cmd, fmt.Sprintf("\tSize of %-85s %v", fileSpecSrc, convertBytes(fileSize)))
 
 			// Stream the file to disk and write the local file to the tar
 			err = streamFileFromPod(config, tw,
@@ -1967,8 +1967,8 @@ func getRemoteFileSize(config *rest.Config,
 	return size, nil
 }
 
-// ConvertBytes converts a byte size (int64) into a human-readable format.
-func ConvertBytes(bytes int64) string {
+// convertBytes converts a byte size (int64) into a human-readable format.
+func convertBytes(bytes int64) string {
 	const unit = 1024
 	if bytes < unit {
 		return fmt.Sprintf("%d B", bytes)

--- a/internal/cmd/export.go
+++ b/internal/cmd/export.go
@@ -1050,6 +1050,7 @@ func gatherPostgresLogsAndConfigs(ctx context.Context,
 			// fileSpecSrc is namespace/podname:path/to/file
 			// fileSpecDest is the local destination of the file
 			// These are used to help the user grab the file manually when necessary
+			// e.g. postgres-operator/hippo-instance1-vp9k-0:pgdata/pg16/log/postgresql-Tue.log
 			fileSpecSrc := fmt.Sprintf("%s/%s:%s", namespace, pod.Name, logFile)
 			fileSpecDest := filepath.Join(localDirectory, logFile)
 			writeInfo(cmd, fmt.Sprintf("\tSize of %-85s %v", fileSpecSrc, ConvertBytes(fileSize)))


### PR DESCRIPTION
gathering large Postgres files may pose a challenge for some systems. This change stores the file on disk, compares the filesize with the remote, and adds the local file to the tar. It has error handling to allow a support export to be generated when there are issues with gathering PG logs.