### PR TITLE
PGO Monitoring label change

### DIFF
--- a/internal/util/naming.go
+++ b/internal/util/naming.go
@@ -29,8 +29,9 @@ const (
 	// LabelRole is used to identify object roles.
 	LabelRole = labelPrefix + "role"
 
-	// LabelMonitoring is used to identify monitoring Pods
-	LabelMonitoring = "app.kubernetes.io/name=postgres-operator-monitoring"
+	// LabelMonitoring is used to identify monitoring Pods.
+	// Older versions of PGO monitoring use the label 'postgres-operator-monitoring'.
+	LabelMonitoring = "app.kubernetes.io/name in (postgres-operator-monitoring,crunchy-monitoring)"
 
 	// LabelOperator is used to identify operator Pods
 	LabelOperator = "postgres-operator.crunchydata.com/control-plane"


### PR DESCRIPTION
PGO Monitoring changed a label in a recent update. This causes the CLI to miss the relevant Monitoring Pods. This fix looks for either label since an older PGO Monitoring stack may still be in use.